### PR TITLE
Implemented wandb entity configuration

### DIFF
--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -134,6 +134,7 @@ class GeneralArgs:
 
     Args:
         project: Name of the project (a project gather several runs in common tensorboard/hub-folders)
+        entity: Weights and bias entity name (optional)
         run: Name of the run
         step: Global step (updated when we save the checkpoint)
         consumed_train_samples: Number of samples consumed during training (should be actually just step*batch_size)
@@ -141,6 +142,7 @@ class GeneralArgs:
     """
 
     project: str
+    entity: Optional[str] = None
     run: Optional[str] = None
     seed: Optional[int] = None
     step: Optional[int] = None

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -247,6 +247,7 @@ class DistributedTrainer:
             wandb.init(
                 project=self.config.general.project,
                 name=f"{current_time}_{self.config.general.project}_{self.config.general.run}",
+                entity=self.config.general.entity,
                 config={"nanotron_config": self.config.as_dict()},
             )
 


### PR DESCRIPTION
Weights and biases organizes its runs across several entities (users or teams). Team entities allow several users to push related runs to the same place. This simple PR allows nanotron users to select which entity they would like to push their logs using the `general.entity` configuration.