### PR TITLE
FA3 Tracking

### DIFF
--- a/examples/config_llama3_fa3.yaml
+++ b/examples/config_llama3_fa3.yaml
@@ -1,0 +1,95 @@
+checkpoints:
+  checkpoint_interval: 1000
+  checkpoints_path: checkpoints/
+  checkpoints_path_is_shared_file_system: false
+  resume_checkpoint_path: null
+  save_initial_state: false
+data_stages:
+- data:
+    dataset:
+      dataset_folder: /store/swissai/a06/datatrove/fineweb-edu-sample-100BT
+    num_loading_workers: 1
+    seed: 42
+  name: General purpose training (Single dataset)
+  start_training_step: 1
+general:
+  benchmark_csv_path: null
+  consumed_train_samples: null
+  ignore_sanity_checks: true
+  project: Nanoset
+  run: llama
+  seed: 42
+  step: null
+lighteval: null
+logging:
+  iteration_step_info_interval: 1
+  log_level: info
+  log_level_replica: info
+model:
+  ddp_bucket_cap_mb: 25
+  dtype: float16
+  init_method:
+    std: 0.025
+  make_vocab_size_divisible_by: 1
+  model_config:
+    bos_token_id: 128000
+    eos_token_id: 128001
+    hidden_act: silu
+    hidden_size: 4096
+    initializer_range: 0.02
+    intermediate_size: 14336
+    is_llama_config: true
+    max_position_embeddings: 8192
+    num_attention_heads: 32
+    num_hidden_layers: 11
+    num_key_value_heads: 32
+    pad_token_id: null
+    pretraining_tp: 1
+    rms_norm_eps: 1.0e-05
+    rope_interleaved: false
+    rope_scaling: null
+    rope_theta: 500000.0
+    tie_word_embeddings: false
+    use_cache: true
+    vocab_size: 128256
+    use_fa3: false
+optimizer:
+  accumulate_grad_in_fp32: true
+  clip_grad: 1.0
+  learning_rate_scheduler:
+    learning_rate: 0.0003
+    lr_decay_starting_step: null
+    lr_decay_steps: 98
+    lr_decay_style: cosine
+    lr_warmup_steps: 2
+    lr_warmup_style: linear
+    min_decay_lr: 1.0e-05
+  optimizer_factory:
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    name: adamW
+    torch_adam_is_fused: true
+  weight_decay: 0.01
+  zero_stage: 0
+parallelism:
+  dp: 1
+  expert_parallel_size: 1
+  pp: 1
+  pp_engine: 1f1b
+  tp: 1
+  tp_linear_async_communication: false
+  tp_mode: REDUCE_SCATTER
+profiler: null
+tokenizer:
+  tokenizer_max_length: null
+  tokenizer_name_or_path: /store/swissai/a06/models/Meta-Llama-3-8B
+  tokenizer_revision: null
+tokens:
+  batch_accumulation_per_replica: 1
+  limit_test_batches: 0
+  limit_val_batches: 0
+  micro_batch_size: 1
+  sequence_length: 8192
+  train_steps: 200
+  val_check_interval: -1 

--- a/src/nanotron/config/models_config.py
+++ b/src/nanotron/config/models_config.py
@@ -54,6 +54,7 @@ class LlamaConfig:
     tie_word_embeddings: bool = False
     use_cache: bool = True
     vocab_size: int = 32000
+    use_fa3: bool = False # To switch between FA implementations
 
     def __post_init__(self):
         # NOTE: user don't set self._init_method, ModelArgs will set it

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -210,6 +210,43 @@ class CoreAttention(nn.Module):
         )
 
         return attn_output
+    
+class CoreAttentionFA3(nn.Module):
+    def __init__(self, config: LlamaConfig, parallel_config: Optional[ParallelismArgs], layer_idx: int):
+        super().__init__()
+        # TODO @thomasw21: GPT has a weird `d_kv` config which I'm guessing is essentically a `d_qkv`
+        assert (
+            config.hidden_size % config.num_attention_heads == 0
+        ), f"Hidden size {config.hidden_size} must be divisible by number of attention heads {config.num_attention_heads}."
+        self.d_qk = config.hidden_size // config.num_attention_heads
+        self.d_v = config.hidden_size // config.num_attention_heads
+        self.is_using_mup = config.is_using_mup
+
+        self.checkpoint_attention = False  # Because flash_attn already does checkpointing
+
+    @checkpoint_method(attr_name="checkpoint_attention")
+    def forward(
+        self,
+        query_states: torch.Tensor,  # [batch_size, q_length, n_local_q_heads, inner_dim]
+        key_states: torch.Tensor,  # [batch_size, kv_length, n_local_kv_heads, inner_dim]
+        value_states: torch.Tensor,  # [batch_size, kv_length, n_local_kv_heads, inner_dim]
+    ):
+        from flash_attn_interface import flash_attn_func
+
+        # NOTE: this scale is for µTransfer,
+        # in SP, we use sqrt(1/d_h)
+        softmax_scale = 1 / query_states.shape[-1] if self.is_using_mup else None
+        # For now we are assuming that we use causual mask. No magic here
+        causal = True
+        attn_output = flash_attn_func(
+            q=query_states.contiguous(),
+            k=key_states.contiguous(),
+            v=value_states.contiguous(),
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+
+        return attn_output[0]
 
 
 def pad_to_right(tensor, mask, new_tensor=None):
@@ -322,12 +359,19 @@ class CausalSelfAttention(nn.Module, AttachableStore):
             bias=False,
             async_communication=tp_linear_async_communication,
         )
-
-        self.attention = CoreAttention(
+        if config.use_fa3:
+            self.attention = CoreAttentionFA3(
             config,
             parallel_config=parallel_config,
             layer_idx=layer_idx,
-        )
+            )
+        
+        else:
+            self.attention = CoreAttention(
+                config,
+                parallel_config=parallel_config,
+                layer_idx=layer_idx,
+            )
 
         self.prefill_kv_len = (
             config.max_position_embeddings


### PR DESCRIPTION
In this branch, we will track the evolution of FA3. The current state is:
- No MQA/GQA
- No BF16
- Requires contiguous inputs

From the flash-attention repo:
- Coming soon in the next couple of days / next week:
- BF16
- Variable length (FP16, BF16)
- FP8 forward

# Installation
Refer to the [official FA repo](https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file#flashattention-3-beta-release).
This will install the package `flashattn-hopper`, so you can still have `flash_attn`for the LayerNorm and RoPE embeddings.

# Run experiments
In this branch, I have added the configuration to choose between FA2 & FA3 to more easily compare the performance of both ([`model.model_config.use_fa3`](https://github.com/swiss-ai/nanotron/blob/3cfc795b20a3f5a30d085add40e87ed8dcdcff2e/examples/config_llama3_fa3.yaml#L55)). You can use the configuration [`examples/config_llama3_fa3.yaml`](https://github.com/swiss-ai/nanotron/blob/3cfc795b20a3f5a30d085add40e87ed8dcdcff2e/examples/config_llama3_fa3.yaml) that will build a Llama3-8B model but with fewer decoder layers to fit the 8192 sequence length in 1 GPU.

If we use GH200 nodes, having more VRAM will allow us to use `num_hidden_layers = 11`. In systems with H100, use `num_hidden_layers = 8`. Don't forget to edit the `dataset_folder` and `tokenizer_name_or_path` fields if necessary.

# Performance
I will keep updating this table as new features are incorporated, as they mentioned, they are currently in a beta release. The MFU reported is the one [computed by nanotron](https://github.com/swiss-ai/nanotron/blob/3cfc795b20a3f5a30d085add40e87ed8dcdcff2e/src/nanotron/models/llama.py#L994). 

|   Date   |   FA  | Precision | num_attention_heads | num_key_value_heads | num_hidden_layers | Batch Size | Sequence Length |   MFU (TFLOPs)   |  VRAM  |
|:--------:|:-----:|:---------:|:-------------------:|:-------------------:|:-----------------:|:----------:|:---------------:|:-------:|:------:|
|   12/7   |   2   |    bf16   |          32         |          32         |         11        |      1     |       8192      |   348   |   94   |
|   12/7   |   2   |    fp16   |          32         |          32         |         11        |      1     |       8192      |   381   |   94   |
| **12/7** | **3** |  **fp16** |        **32**       |        **32**       |       **11**      |    **1**   |     **8192**    | **446** | **94** |
|   12/7   |   2   |    bf16   |          32         |          32         |         8         |      1     |       8192      |   342   |   77   |
|   12/7   |   2   |    fp16   |          32         |          32         |         8         |      1     |       8192      |   370   |   77   |
| **12/7** | **3** |  **fp16** |        **32**       |        **32**       |       **8**       |    **1**   |     **8192**    | **433** | **77** |