### PR TITLE
Tweak Pipeline Parallel layer split strategy

### DIFF
--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -813,15 +813,12 @@ class LlamaModel(nn.Module):
 
     def get_block_compute_costs(self):
         """Computes the compute cost of each block in the model so that we can do a better job of load balancing."""
-        model_config = self.config
-        d_ff = model_config.intermediate_size
-        d_qkv = model_config.hidden_size // model_config.num_attention_heads
         block_compute_costs = {
             # CausalSelfAttention (qkv proj + attn out) + MLP
-            LlamaDecoderLayer: 4 * model_config.num_attention_heads * d_qkv * model_config.hidden_size
-            + 3 * d_ff * model_config.hidden_size,
+            Embedding: 1,
+            LlamaDecoderLayer: 1,
             # This is the last lm_head
-            TensorParallelColumnLinear: model_config.vocab_size * model_config.hidden_size,
+            TensorParallelColumnLinear: 1,
         }
         return block_compute_costs
 


### PR DESCRIPTION
The previous pipelineblock split strategy in nanotron tries to evenly split the layers to each device in terms of FLOPs. However, since the embedding table is becoming larger and larger, memory consumption should be taken into account. 

We follow the practice in Llama 405B training, which treat the embedding table and lm head as heavy as a single transformer block. (This is why 405B model has 126 layers.)

Any suggestions for better general strategy?

e.g. a 32-layer llama model and PP=4:

Prev:
![image](https://github.com/user-attachments/assets/281b4b78-d5d4-49ab-96fc-2d5f417e2b34)


After:
![image](https://github.com/user-attachments/assets/13f77955-339d-47cf-922d-43852ce30bd7)
