### PR TITLE
Fixed wrong lr initialization when loading checkpoints

### DIFF
--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -209,6 +209,13 @@ class DistributedTrainer:
                 parallel_context=self.parallel_context,
                 root_folder=self.init_checkpoint_path,
             )
+            # Update optimizer learning rate because otherwise it is set to zero in the first iteration.
+            param_groups = self.optimizer.get_base_optimizer().param_groups
+            last_lrs = self.lr_scheduler.get_last_lr()
+            assert len(param_groups) == len(last_lrs)
+            for group, last_lr in zip(param_groups, last_lrs):
+                assert "lr" in group
+                group["lr"] = last_lr
 
         # Define iteration start state
         if self.init_checkpoint_path is not None:


### PR DESCRIPTION
For some reason the `lr` in the parameter groups of the optimizers is set to zero in the very first iteration. This is problematic when loading checkpoints as it essentially means you are no longer following the same training as an uninterrupted run, but rather skipping one optimization iteration. This PR fixes this issue.

Minimalistic example:
![image](https://github.com/user-attachments/assets/6aa1563b-5234-40ff-8930-a7c75d12de9c)
Green follows a 10 iteration training without interruption. Orange is the current behaviour, loading from iteration 5 and quickly diverging because of the incorrect lr set when loading. Brown (overlapping green) is the fix loading from iteration 5 but now follows the same expected route.